### PR TITLE
Added sequential rod selection to bottom fishing

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,306 @@
+; ---------------------------------------------------------------------------- ;
+;    This is a template for configuration, edit your settings in config.ini    ;
+; ---------------------------------------------------------------------------- ;
+; the line starts with ";" are just comments and are not necessary
+; the unit of duration, delay, timeout, etc, is seconds
+
+; ---------------------------------------------------------------------------- ;
+;                               general settings                               ;
+; ---------------------------------------------------------------------------- ;
+[game]
+; available options: en, ru, zh-TW, zh-CN
+language = en
+
+; default options that will be merged into command line arguments
+; use app.py -h to see help messages about the options
+; example: -rcH
+default_arguments =
+
+; set this to False to stop the scrip from asking for confirmation at startup
+confirmation_enabled = True
+
+; set this to False to disable smtp validation at startup
+SMTP_validation_enabled = True
+
+; set this to False to disable file integrity verification at startup
+image_verification_enabled = True
+
+; the size of your keepnet, set this to 150 if premium is enabled
+keepnet_limit = 100
+
+; maximum number of coffee to drink in a single fish fight
+; if limit is reached, the script will be terminated without closing the game
+coffee_limit = 10
+
+; time to wait before keeping the fish for users to take screenshot
+keep_fish_delay = 1
+
+; minimum threshold of energy bar for baits harvesting and coffee drinking,
+; increase this if your account level is not high enough
+energy_threshold = 0.74
+
+; confidence of retrieval detection, use smaller value if the retrieval get stuck
+retrieval_detect_confidence = 0.985
+
+; time interval between each drinks
+alcohol_drinking_delay = 900
+
+; how many bottles of wine to drink at one time
+alcohol_drinking_quantity = 1
+
+; action to be performed when lure is broken, available options: quit, alarm, replace
+lure_broken_action = quit
+
+; action to be performed when keepnet is full, available options: quit, alarm
+keepnet_full_action = quit
+
+; an absolute or relative path of sound file (.mp3, .wav) for alarm sound
+alarm_sound_file = ..\static\sound\guitar.wav
+
+; whitelist for unmarked fish releasing when using -m flag
+; available options: mackerel, saithe, herring, squid, scallop, mussel or None
+unmarked_release_whitelist = mackerel, saithe
+
+; quit if the tackle is snagged
+snag_detection_enabled = True
+
+
+; recast the spod rod every "spod_rod_recast_delay" seconds
+; use -o flag to enable this feature
+spod_rod_recast_delay = 1800
+
+; friction brake will be set to "initial friction brake" when -f flag is used
+; the upper bound is "max_friction_brake"
+initial_friction_brake = 29
+max_friction_brake = 30
+
+; delay before increase friction brake, the shorter it is, the greater the chance of
+; the gear breaking, use -f flag to enable auto friction brake changing
+friction_brake_increase_delay = 1
+
+; delay before start adjusting the friction brake after a fish is hooked,
+; use -f flag to enable auto friction brake changing
+friction_brake_adjust_delay = 2
+
+; for spin fishing, change a random favorite lure every "lure_changing_delay" seconds
+; use -L flag to enable this feature
+lure_changing_delay = 1800
+
+; pause the script "pause_duration" seconds every "pause_delay"
+; use -X flag to enable this feature
+pause_duration = 600
+pause_delay = 180
+
+; how many coffee to drink at a time
+coffee_drinking_quantity = 1
+
+
+; ---------------------------------------------------------------------------- ;
+;                                   shortcuts                                  ;
+; ---------------------------------------------------------------------------- ;
+; to reserve quick selection slot for other items, you can use -1 as the shortcut
+; in this case, the bot will select the item through the quick selection menu
+; currently, only common foods like tea, carrot and coffee support -1 as their values
+[shortcut]
+tea = -1
+carrot = -1
+bottom_rods = 1, 2, 3
+coffee = 4
+shovel_spoon = 5
+alcohol = 6
+spod_rod = 7
+
+; if you want to enable baits harvesting when using spin or float fishing mode, the
+; hotkey of rod you use must be set correctly
+main_rod = 1
+
+; edit this to add a hotkey to stop the script other than typing Ctrl-C in terimnal,
+; if you want to use a special quitting shortcut, please refer to pynput's docs:
+; https://pynput.readthedocs.io/en/latest/keyboard.html#pynput.keyboard.Key
+quit = Ctrl-C
+
+
+; ---------------------------------------------------------------------------- ;
+;                                 user profiles                                ;
+; ---------------------------------------------------------------------------- ;
+; here are some common options that are used in almost every user profile:
+
+; fishing_strategy: profile's fishing strategy
+; available options: spin, spin_with_pause, bottom, marine, float, wakey_rig
+
+; cast_power_level: power level for casting, 1 ~ 5
+; 1: 0%, 2: ~25%, 3: ~50%, 4: ~75% 5: 100%+ (power cast), FYR
+; For instance, 2.5 cast_power_level equals to 37.5% casting power
+
+; cast_delay: time to wait for the lure to fly or sink under the water
+
+; post_acceleration_enabled: hold down the Shift key when fighting against the fish
+; available options: always, never, auto
+; if set to auto, the Shift key will be released after the first timeout
+
+; You can also create your own user profile like this:
+; [your_profile_name]
+; fishing_strategy = spin_with_pause
+; cast_power_level = 3
+;   .
+;   .
+;   .
+
+; ---------------------------------------------------------------------------- ;
+;                             spin fishing profiles                            ;
+; ---------------------------------------------------------------------------- ;
+[spin_example]
+fishing_strategy = spin
+cast_power_level = 5
+cast_delay = 6
+post_acceleration_enabled = never
+
+; ---------------------------------------------------------------------------- ;
+;                       spin fishing with pause profiles                       ;
+; ---------------------------------------------------------------------------- ;
+; this is a special spin fishing designed for jig step, walk the dog, twitching, etc
+[spin_with_pause_example]
+fishing_strategy = spin_with_pause
+cast_power_level = 5
+cast_delay = 6
+post_acceleration_enabled = never
+
+; duration of holding down the left mouse button
+retrieval_duration = 1.1
+
+; delay time after releasing the left mouse button
+retrieval_delay = 3
+
+; hold down the Shift key when performing special spin fishing techniques
+pre_acceleration_enabled = False
+
+
+; ---------------------------------------------------------------------------- ;
+;                            bottom fishing profiles                           ;
+; ---------------------------------------------------------------------------- ;
+[bottom_example]
+fishing_strategy = bottom
+cast_power_level = 5
+cast_delay = 4
+post_acceleration_enabled = never
+
+; the time to wait before checking the next rod
+check_delay = 32
+
+; ---------------------------------------------------------------------------- ;
+; random_rod_selection_enabled = true  enables random rod selection during fishing;
+; set this to false if you want to always use the same rod sequence.
+; ---------------------------------------------------------------------------- ;
+random_rod_selection_enabled = False  # Set to false if you do not want random rod selection
+
+
+; ---------------------------------------------------------------------------- ;
+;                         marine_pirk fishing profiles                         ;
+; ---------------------------------------------------------------------------- ;
+; if pirk_duration and pirk_delay are both zero, no pirking will be performed
+[marine_pirk_example]
+fishing_strategy = marine_pirk
+cast_power_level = 1
+cast_delay = 4
+post_acceleration_enabled = auto
+
+; duration of holding down the right mouse button
+pirk_duration = 0.5
+
+; delay time after releasing the right mouse button
+pirk_delay = 2
+
+; the timeout before adjusting the lure's depth or recast the rod
+pirk_timeout = 32
+
+; action to take when the pirking timed out
+; available options: adjust, recast
+pirk_timeout_action = adjust
+
+; duration of holding down the left mouse button to tighten the fishing line
+tighten_duration = 1.04
+
+; if  the script does not detect "moving at the bottom layer",
+; it will start printing after the sink timeout is reached
+sink_timeout = 60
+
+; when a fish is hooked, it will check if the fish is still hooked
+; after fish_hooked_delay seconds, if not, the pirking continue
+fish_hooked_delay = 0
+
+
+; ---------------------------------------------------------------------------- ;
+;                       marine_elevator fishing profiles                       ;
+; ---------------------------------------------------------------------------- ;
+[marine_elevator_example]
+fishing_strategy = marine_elevator
+cast_power_level = 1
+cast_delay = 4
+post_acceleration_enabled = auto
+
+; timeout before switching lure moving direction in different phase (rise / drop)
+elevate_timeout = 40
+
+; duration of locking the reel or retrieving the line according to the phase
+lock_duration = 4
+
+; duration of unlocking the reel or idling according to the phase
+lock_delay = 4
+
+; duration of holding down the left mouse button to tighten the fishing line
+tighten_duration = 1.04
+
+; if  the script does not detect "moving at the bottom layer",
+; it will start printing after the sink timeout is reached
+sink_timeout = 10
+
+; when a fish is hooked, it will check if the fish is still hooked
+; after fish_hooked_delay seconds, if not, the pirking continue
+fish_hooked_delay = 0
+
+
+; ---------------------------------------------------------------------------- ;
+;                            Float fishing profiles                            ;
+; ---------------------------------------------------------------------------- ;
+[float_example]
+fishing_strategy = float
+cast_power_level = 5
+cast_delay = 4
+post_acceleration_enabled = never
+
+; confidence of float state detection, set it higher to increase sensitivity
+float_confidence = 0.68
+
+; check the float state every check_delay seconds
+check_delay = 1
+
+; after the float state has changed, wait pull_delay seconds before lifting the rod
+pull_delay = 0.5
+
+; recast the rod after the timeout is reached, designed for flowing water maps
+drifting_timeout = 16
+
+
+; ---------------------------------------------------------------------------- ;
+;                          wakey rig fishing profiles                          ;
+; ---------------------------------------------------------------------------- ;
+; this is designed for spin fishing with wakey rig at Ladoga Archipelago
+; if pirk_timeout is set to 0, the line will be retrieved immediately after the lure
+; sinks to the bottom of the water
+[wakey_rig_example]
+fishing_strategy = wakey_rig
+cast_power_level = 1
+cast_delay = 4
+post_acceleration_enabled = never
+pirk_duration = 1.5
+pirk_delay = 4
+pirk_timeout = 32
+pirk_timeout_action = adjust
+tighten_duration = 0.25
+sink_timeout = 45
+fish_hooked_delay = 1
+
+; ---------------------------------------------------------------------------- ;
+;                           trolling fishing profiles                          ;
+; ---------------------------------------------------------------------------- ;
+; not implemented yet


### PR DESCRIPTION
## Description

This pull request adds the functionality for sequential rod selection in the bottom fishing strategy. It introduces a new setting `random_rod_selection_enabled` in the `config.ini` file, which allows users to enable or disable random rod selection. When disabled, rods are selected in sequence (1, 2, 3, etc.).

## Changes Made

- Added `random_rod_selection_enabled` setting to `config.ini`.
- Updated `player.py` to include logic for sequential rod selection in the `bottom_fishing` method.
- Updated `setting.py` to include the new configuration option.

## How to Test

1. Update your `config.ini` file to include the new setting:

2. Run the script and select the bottom fishing strategy.
3. Observe that the rods are selected sequentially if the setting is disabled.