### PR TITLE
Add sequential rod order functionality to bottom fishing

### DIFF
--- a/src/player.py
+++ b/src/player.py
@@ -187,7 +187,10 @@ class Player:
             self._refill_user_stats()
             self._harvesting_stage()
             if rod_count > 1:
-                rod_idx = (rod_idx + random.randint(1, rod_count - 1)) % rod_count
+                if self.setting.use_random_rod_selection:
+                    rod_idx = (rod_idx + random.randint(1, rod_count - 1)) % rod_count
+                else:  # sequential
+                    rod_idx = (rod_idx + 1) % rod_count
             rod_key = self.setting.bottom_rods_shortcuts[rod_idx]
             logger.info("Checking rod %s", rod_idx + 1)
             pag.press(f"{rod_key}")

--- a/src/setting.py
+++ b/src/setting.py
@@ -47,7 +47,8 @@ GENERAL_CONFIGS = (
     ("lure_changing_delay", "Lure changing delay", int),
     ("pause_duration", "Pause duration", int),
     ("pause_delay", "Pause delay", int),
-    ("coffee_drinking_quantity", "Coffee drinking quantity", int)
+    ("coffee_drinking_quantity", "Coffee drinking quantity", int),
+    ("use_random_rod_selection", "Use random rod selection", bool),
 )
 
 # ----------------------- config name - attribute name ----------------------- #

--- a/template.ini
+++ b/template.ini
@@ -98,6 +98,11 @@ pause_delay = 180
 ; how many coffee to drink at a time
 coffee_drinking_quantity = 1
 
+; use_random_rod_selection: True or False
+; If set to True, the script will randomly select a rod for bottom fishing.
+; If set to False, the script will select rods sequentially in order (1, 2, 3, ...).
+use_random_rod_selection = True
+
 ; ---------------------------------------------------------------------------- ;
 ;                                   shortcuts                                  ;
 ; ---------------------------------------------------------------------------- ;


### PR DESCRIPTION
Added sequential rod order functionality to bottom fishing

- Updated player.py to include sequential rod order in the bottom_fishing method.
- Added new setting in setting.py to toggle between random and sequential rod order.
- Updated template.ini to include configuration options for use_random_rod_selection.

Sequential rod order allows the player to switch rods in sequence (1, 2, 3) rather than randomly.